### PR TITLE
Add $(set -e) into concat.sh to exit on errors.

### DIFF
--- a/concat.sh
+++ b/concat.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# avoid deleting file, if convert will fail
+set -e
+
 output=${1-"output.gif"}
 prev_delay=0
 skipped=0


### PR DESCRIPTION
$(convert) command may killed by oom killer, and in this case we mustn't
delete temporary gifs.
