### PR TITLE
Add install instructions for fedora/redhat

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ $ cd ttygif
 $ make
 ```
 
+### Fedora/Redhat
+``` sh
+$ sudo yum install ImageMagick gcc
+$ # install ttyrec from source ~> https://github.com/mjording/ttyrec
+$ git clone https://github.com/icholy/ttygif.git
+$ cd ttygif
+$ make
+```
+
 ### OSX
 ``` sh
 $ brew install imagemagick ttyrec


### PR DESCRIPTION
On Fedora/RedHat:
- ImageMagick package is camel cased, go figure why
- ttyrec rpm is not available for the latest fedora
