### PR TITLE
Fail if $WINDOWID isn't set

### DIFF
--- a/ttygif.c
+++ b/ttygif.c
@@ -132,6 +132,11 @@ ttyplay (FILE *fp, ReadFunc read_func, WriteFunc write_func)
 
     char* wid = getenv("WINDOWID");
 
+    if (wid == NULL || !strlen(wid)) {
+        printf("Error: WINDOWID environment variable was empty.");
+        exit(EXIT_FAILURE);
+    }
+
     while (1) {
 
         char *buf;


### PR DESCRIPTION
If you run `ttygif` on a headless server, or in other scenarios (see #15), your `$WINDOWID` environment variable might not be set.

This helps improve the error message. Specifically, the error scenario would go from:

(OLD)

![screenshot 2014-05-18 11 48 26](https://cloud.githubusercontent.com/assets/563658/3007898/e1afa674-dea3-11e3-9ba4-edd107a78a61.png)

to:

(NEW)

![screenshot 2014-05-18 11 49 26](https://cloud.githubusercontent.com/assets/563658/3007901/02b6780c-dea4-11e3-9eb4-4f2480fb4aae.png)
