### PR TITLE
Use bash from $PATH instead of hard-coded /bin/bash

### DIFF
--- a/concat.sh
+++ b/concat.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # avoid deleting file, if convert will fail
 set -e

--- a/concat_osx.sh
+++ b/concat_osx.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 output=${1-"output.gif"}
 prev_delay=0


### PR DESCRIPTION
This is *supposed* to be better for cross-platform usage, at least in most cases.
http://stackoverflow.com/questions/10376206/preferred-bash-shebang
http://unix.stackexchange.com/questions/29608/why-is-it-better-to-use-usr-bin-env-name-instead-of-path-to-name-as-my