### PR TITLE
Fix off-by-one frame timing error

### DIFF
--- a/concat.sh
+++ b/concat.sh
@@ -5,6 +5,7 @@ set -e
 
 output=${1-"output.gif"}
 prev_delay=0
+prev_gif=""
 skipped=0
 
 gifs=$(find . -maxdepth 1 -name '*.gif'| grep -v "$output" | sort | xargs)
@@ -31,8 +32,12 @@ for gif in $gifs; do
 
     prev_delay=$delay
 
-    _convert="$_convert -delay $delay $gif"
+    if [ -n "$prev_gif" ]; then
+        _convert="$_convert -delay $delay $prev_gif"
+    fi
+    prev_gif=$gif
 done;
+_convert="$_convert $gif"
 
 _convert="$_convert -layers Optimize $output"
 

--- a/concat_osx.sh
+++ b/concat_osx.sh
@@ -2,6 +2,7 @@
 
 output=${1-"output.gif"}
 prev_delay=0
+prev_png=""
 skipped=0
 
 pngs=$(find . -maxdepth 1 -name '*.png'| grep -v "$output" | sort | xargs)
@@ -28,8 +29,12 @@ for png in $pngs; do
 
     prev_delay=$delay
 
-    _convert="$_convert -delay $delay $png"
+    if [ -n "$prev_png" ]; then
+        _convert="$_convert -delay $delay $prev_png"
+    fi
+    prev_png=$png
 done;
+_convert="$_convert $png"
 
 _convert="$_convert -layers Optimize $output"
 

--- a/ttygif.c
+++ b/ttygif.c
@@ -107,6 +107,8 @@ take_snapshot(int index, int delay, char* window_id)
 {
   static char cmd [256];
 
+  // ensure text has been written before taking screenshot
+  usleep(50000);
   if (sprintf(cmd, "import -window %s %05d_%d.gif", window_id, index, delay) < 0) {
       return -1;
   }


### PR DESCRIPTION
When using the OS X version, pausing at the start before typing anything, I noticed that the timing seemed to be off by one frame, with a long pause on the first letter:

![output](https://cloud.githubusercontent.com/assets/4431336/6426459/8a1f6cc8-bf53-11e4-8c25-36908c8f8d7c.gif)

With the same record, though, the issue wasn't happening on Ubuntu:

![foo](https://cloud.githubusercontent.com/assets/4431336/6426477/9080aa22-bf54-11e4-88e8-3595e9de7a81.gif)

Investigating a bit more closely, it looks like with gnome-terminal, the 'import' was taking the screenshot before the last character had actually appeared on the terminal - adding a `usleep(50000)` before the screenshot command gave the same behaviour as OS X.

I've modified `concat_osx.sh` to use the delay from the previous file looked at, and have bodged a fix into the Linux version by just leaving the `usleep` in and similarly reordering `concat.sh`.

(P.S. Thank you for the awesome tool :D)