### PR TITLE
osx homebrew: also install concat_osx.sh

### DIFF
--- a/ttygif.rb
+++ b/ttygif.rb
@@ -11,5 +11,6 @@ class Ttygif < Formula
   def install
     system 'make'
     bin.install('ttygif')
+    bin.install('concat_osx.sh')
   end
 end


### PR DESCRIPTION
the homebrew formula didn't install the `concat_osx.sh` helper script; now it does :)