### PR TITLE
Update expected SHA1 for release 1.0.8

### DIFF
--- a/ttygif.rb
+++ b/ttygif.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Ttygif < Formula
   homepage 'https://github.com/icholy/ttygif'
   url 'https://github.com/icholy/ttygif/archive/1.0.8.zip'
-  sha1 'f8d0a56af11d3ae8e2d5e64a4f6aceccb8338414'
+  sha1 '00e76af8ac11d8522ff32d5c86cba07545bf54c6'
 
   depends_on 'imagemagick'
   depends_on 'ttyrec'


### PR DESCRIPTION
Hi there, 

I ran into the following error trying to install on OS X:

```
[@leereilly ~]$ brew install https://raw.githubusercontent.com/icholy/ttygif/master/ttygif.rb
######################################################################## 100.0%
==> Downloading https://github.com/icholy/ttygif/archive/1.0.8.zip
######################################################################## 100.0%
Error: SHA1 mismatch
Expected: f8d0a56af11d3ae8e2d5e64a4f6aceccb8338414
Actual: 00e76af8ac11d8522ff32d5c86cba07545bf54c6
Archive: /opt/boxen/cache/homebrew/ttygif-1.0.8.zip
To retry an incomplete download, remove the file above.
```

Updating the SHA1 for https://github.com/icholy/ttygif/archive/1.0.8.zip seems to work :metal:

Cheers,
  Lee :beers: