### PR TITLE
Remove all output from 'convert' on TTYGIF OS X version, since it sometimes ignores the -quiet flag and complains, ruining the output GIF.

### DIFF
--- a/ttygif_osx.c
+++ b/ttygif_osx.c
@@ -122,7 +122,7 @@ take_snapshot(int index, int delay, struct osx_config osx_options)
   }
 
   if (osx_options.fullscreen == 0) {
-    if (sprintf(cmd, "convert %05d_%d.png -background white -quiet -flatten +matte -crop +0+22 -crop +4+0 -crop -4-0 +repage %05d_%d.png", index, delay, index, delay) < 0) {
+    if (sprintf(cmd, "convert %05d_%d.png -background white -quiet -flatten +matte -crop +0+22 -crop +4+0 -crop -4-0 +repage %05d_%d.png &> /dev/null", index, delay, index, delay) < 0) {
         return -1;
     }
   }


### PR DESCRIPTION
I just added the same "&> /dev/null" as it is used for the call to screen capture just above it.

The error I was getting was:

**convert: profile 'icc': 'RGB ': RGB color space not permitted on grayscale PNG `00000_0.png' @ warning/png.c/MagickPNGWarningHandler/1831.**

Removing the "-background white" param also fixed this specific error, but someone must have put that there for a reason. These things would be better done as command line arguments, but of course more work is needed. This is just a quick fix with hopefully no ill effects.

The specific setup is that I was capturing a simple tty session in OS X Yosemite, using iTerm2, and the first frame captured was in grayscale format. It seems 'screen capture' just generates a grayscale PNG if no colors are found. Apart from producing the error message, the "convert" command works just fine.

Here's the commit message:

Redirected output of convert to /dev/null, since it sometimes complai…ns despite the -quiet option (specifically, when a PNG is grayscale, due to the -background white option - and screencapture does generate grayscale PNGs if no colors are present). Error message showed up in the generated GIF.