### PR TITLE
Ensured first frame is always included in the GIF file

### DIFF
--- a/concat.sh
+++ b/concat.sh
@@ -20,7 +20,7 @@ for xwd in $xwds; do
     delay=$(echo "${name#*_} * 0.1" | bc)
 
     # remove this is you don't want to trim zero delay frames
-    if [ -n "$prev_png" ] && [ $delay == 0 ] && [ $prev_delay == 0 ]; then
+    if [ -n "$prev_xwd" ] && [ $delay == 0 ] && [ $prev_delay == 0 ]; then
         if [ $skipped -lt 5 ]; then
           skipped=$(($skipped + 1))
           prev_delay=$delay

--- a/concat.sh
+++ b/concat.sh
@@ -20,7 +20,7 @@ for xwd in $xwds; do
     delay=$(echo "${name#*_} * 0.1" | bc)
 
     # remove this is you don't want to trim zero delay frames
-    if [ $delay == 0 ] && [ $prev_delay == 0 ]; then
+    if [ -n "$prev_png" ] && [ $delay == 0 ] && [ $prev_delay == 0 ]; then
         if [ $skipped -lt 5 ]; then
           skipped=$(($skipped + 1))
           prev_delay=$delay

--- a/concat_osx.sh
+++ b/concat_osx.sh
@@ -17,7 +17,7 @@ for png in $pngs; do
     delay=$(echo "${name#*_} * 0.1" | bc)
 
     # remove this is you don't want to trim zero delay frames
-    if [ $delay == 0 ] && [ $prev_delay == 0 ]; then
+    if [ -n "$prev_png" ] && [ $delay == 0 ] && [ $prev_delay == 0 ]; then
         if [ $skipped -lt 5 ]; then
           skipped=$(($skipped + 1))
           prev_delay=$delay


### PR DESCRIPTION
The 0-delay-skip optimization tended to get rid of the first frame (since it shows "0" delay), and this ruined some animations. The fix ensures the first frame is always included, and it is done using exactly the same technique used elsewhere in the script to check for the existence of the previous frame (if [ -n "$prevpng"]), so it shouldn't cause any issue.