### PR TITLE
Updates install instructions on Debian/Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ### Debian/Ubuntu
 ``` sh
-$ sudo apt-get install imagemagick ttyrec gcc
+$ sudo apt-get install imagemagick ttyrec gcc x11-apps
 $ git clone https://github.com/icholy/ttygif.git
 $ cd ttygif
 $ make


### PR DESCRIPTION
It looks like in (at least some) Debian distros, `xwd` is not available as the package `x11-apps` is not installed. As a consequence, after executing `ttygif`, a `xwd command not found` error will show up. Adding the package to the list of dependencies will solve the issue.