### PR TITLE
Update README.md for fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ $ sudo make install
 
 ### Fedora/Redhat
 ``` sh
-$ sudo yum install ImageMagick gcc
-$ # install ttyrec from source ~> https://github.com/mjording/ttyrec
+$ sudo dnf install ImageMagick gcc
+$ # install ttyrec from source patched ~> https://github.com/mattwilmott/ttyrec
 $ git clone https://github.com/icholy/ttygif.git
 $ cd ttygif
 $ make


### PR DESCRIPTION
Hi,

I updated the README to replace `yum` by `dnf`. By the way I replaced "https://github.com/mjording/ttyrec" by "https://github.com/mattwilmott/ttyrec" because the code in the first repository doesn't work anymore (cf https://github.com/mjording/ttyrec/issues/3).