### PR TITLE
Fix compatibility issue with C99

### DIFF
--- a/ttygif.c
+++ b/ttygif.c
@@ -359,7 +359,10 @@ main (int argc, char **argv)
     }
 
     if (argc >= 3) {
-        for (int i=0; i<argc; i++)
+        
+        int i;
+
+        for (i=0; i<argc; i++)
         {
             if (strstr(argv[i], "-f") || strstr(argv[i], "--fullscreen")) {
                 options.fullscreen = true;


### PR DESCRIPTION
I was trying to build the project on my machine (a very old Asus eeePC) and I stumbled upon this

```
error: 'for' loop initial declaration used outside C99 mode
```
To be honest I don't know if it's better doing what I did or else changing the makefile adding the `-std=C99` option
